### PR TITLE
[dev-ttn] Implement MsgWithdraw + unit tests (mock)

### DIFF
--- a/sw/ob/x/dex/keeper/msg_server_withdraw.go
+++ b/sw/ob/x/dex/keeper/msg_server_withdraw.go
@@ -1,0 +1,19 @@
+package keeper
+
+import (
+	"context"
+
+	"ob/x/dex/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+func (k msgServer) Withdraw(goCtx context.Context, msg *types.MsgWithdraw) (*types.MsgWithdrawResponse, error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	if err := k.Keeper.Withdraw(ctx, msg.Creator, msg.Amount, msg.Denom); err != nil {
+		return nil, err
+	}
+
+	return &types.MsgWithdrawResponse{}, nil
+}

--- a/sw/ob/x/dex/keeper/msg_server_withdraw_test.go
+++ b/sw/ob/x/dex/keeper/msg_server_withdraw_test.go
@@ -1,0 +1,163 @@
+package keeper_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"cosmossdk.io/math"
+	storetypes "cosmossdk.io/store/types"
+	addresscodec "github.com/cosmos/cosmos-sdk/codec/address"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	"github.com/cosmos/cosmos-sdk/testutil"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/stretchr/testify/require"
+
+	"ob/x/dex/keeper"
+	module "ob/x/dex/module"
+	"ob/x/dex/types"
+)
+
+// mockBankKeeper is a controllable mock for types.BankKeeper.
+type mockBankKeeper struct {
+	// balances holds coins per module name (for SendCoinsFromModuleToAccount)
+	balances map[string]sdk.Coins
+	// sendErr, if set, is returned by SendCoinsFromModuleToAccount
+	sendErr error
+}
+
+func newMockBankKeeper(moduleCoins sdk.Coins) *mockBankKeeper {
+	return &mockBankKeeper{
+		balances: map[string]sdk.Coins{
+			types.ModuleName: moduleCoins,
+		},
+	}
+}
+
+func (m *mockBankKeeper) SpendableCoins(_ context.Context, _ sdk.AccAddress) sdk.Coins {
+	return nil
+}
+
+func (m *mockBankKeeper) GetBalance(_ context.Context, _ sdk.AccAddress, _ string) sdk.Coin {
+	return sdk.Coin{}
+}
+
+func (m *mockBankKeeper) SendCoinsFromAccountToModule(_ context.Context, _ sdk.AccAddress, _ string, _ sdk.Coins) error {
+	return nil
+}
+
+func (m *mockBankKeeper) SendCoinsFromModuleToAccount(_ context.Context, moduleName string, addr sdk.AccAddress, amt sdk.Coins) error {
+	if m.sendErr != nil {
+		return m.sendErr
+	}
+	bal := m.balances[moduleName]
+	if !bal.IsAllGTE(amt) {
+		return errors.New("insufficient funds in module")
+	}
+	m.balances[moduleName] = bal.Sub(amt...)
+	return nil
+}
+
+// initFixtureWithBank creates a fixture wired with the given bank keeper mock.
+func initFixtureWithBank(t *testing.T, bank types.BankKeeper) *fixture {
+	t.Helper()
+
+	encCfg := moduletestutil.MakeTestEncodingConfig(module.AppModule{})
+	addressCodec := addresscodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix())
+	storeKey := storetypes.NewKVStoreKey(types.StoreKey)
+
+	storeService := runtime.NewKVStoreService(storeKey)
+	ctx := testutil.DefaultContextWithDB(t, storeKey, storetypes.NewTransientStoreKey("transient_test_withdraw")).Ctx
+
+	authority := authtypes.NewModuleAddress(types.GovModuleName)
+
+	k := keeper.NewKeeper(
+		storeService,
+		encCfg.Codec,
+		addressCodec,
+		authority,
+		nil,
+		bank,
+	)
+
+	if err := k.Params.Set(ctx, types.DefaultParams()); err != nil {
+		t.Fatalf("failed to set params: %v", err)
+	}
+
+	return &fixture{ctx: ctx, keeper: k, addressCodec: addressCodec}
+}
+
+func TestWithdraw(t *testing.T) {
+	validAddr, _ := addresscodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix()).
+		BytesToString([]byte("signerAddr__________________"))
+
+	moduleBalance := sdk.NewCoins(sdk.NewCoin("ATOM", math.NewInt(5000)))
+
+	tests := []struct {
+		desc    string
+		msg     *types.MsgWithdraw
+		bankErr error
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			desc: "success — full balance",
+			msg:  &types.MsgWithdraw{Creator: validAddr, Amount: "1000", Denom: "ATOM"},
+		},
+		{
+			desc: "success — partial amount",
+			msg:  &types.MsgWithdraw{Creator: validAddr, Amount: "500", Denom: "ATOM"},
+		},
+		{
+			desc:    "invalid creator address",
+			msg:     &types.MsgWithdraw{Creator: "not-a-valid-address", Amount: "100", Denom: "ATOM"},
+			wantErr: true,
+			errMsg:  "invalid address",
+		},
+		{
+			desc:    "invalid amount — zero",
+			msg:     &types.MsgWithdraw{Creator: validAddr, Amount: "0", Denom: "ATOM"},
+			wantErr: true,
+			errMsg:  "invalid amount",
+		},
+		{
+			desc:    "invalid amount — negative string",
+			msg:     &types.MsgWithdraw{Creator: validAddr, Amount: "-50", Denom: "ATOM"},
+			wantErr: true,
+			errMsg:  "invalid amount",
+		},
+		{
+			desc:    "invalid amount — non-numeric",
+			msg:     &types.MsgWithdraw{Creator: validAddr, Amount: "abc", Denom: "ATOM"},
+			wantErr: true,
+			errMsg:  "invalid amount",
+		},
+		{
+			desc:    "insufficient module funds",
+			msg:     &types.MsgWithdraw{Creator: validAddr, Amount: "9999", Denom: "ATOM"},
+			wantErr: true,
+			errMsg:  "insufficient funds",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			bank := newMockBankKeeper(moduleBalance)
+			if tc.bankErr != nil {
+				bank.sendErr = tc.bankErr
+			}
+			f := initFixtureWithBank(t, bank)
+
+			err := f.keeper.Withdraw(sdk.UnwrapSDKContext(f.ctx), tc.msg.Creator, tc.msg.Amount, tc.msg.Denom)
+
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/sw/ob/x/dex/keeper/withdraw.go
+++ b/sw/ob/x/dex/keeper/withdraw.go
@@ -1,0 +1,25 @@
+package keeper
+
+import (
+	"ob/x/dex/types"
+
+	"cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// Withdraw sends coins from the dex module account back to the user.
+func (k Keeper) Withdraw(ctx sdk.Context, creator string, amount string, denom string) error {
+	userAddr, err := sdk.AccAddressFromBech32(creator)
+	if err != nil {
+		return types.ErrInvalidAddress.Wrapf("invalid creator address: %s", err)
+	}
+
+	amt, ok := math.NewIntFromString(amount)
+	if !ok || !amt.IsPositive() {
+		return types.ErrInvalidAmount.Wrap("amount must be a positive integer")
+	}
+
+	coins := sdk.NewCoins(sdk.NewCoin(denom, amt))
+
+	return k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, userAddr, coins)
+}

--- a/sw/ob/x/dex/types/errors.go
+++ b/sw/ob/x/dex/types/errors.go
@@ -8,5 +8,7 @@ import (
 
 // x/dex module sentinel errors
 var (
-	ErrInvalidSigner = errors.Register(ModuleName, 1100, "expected gov account as only signer for proposal message")
+	ErrInvalidSigner  = errors.Register(ModuleName, 1100, "expected gov account as only signer for proposal message")
+	ErrInvalidAddress = errors.Register(ModuleName, 1101, "invalid address")
+	ErrInvalidAmount  = errors.Register(ModuleName, 1102, "invalid amount")
 )

--- a/sw/ob/x/dex/types/msg_withdraw.go
+++ b/sw/ob/x/dex/types/msg_withdraw.go
@@ -1,0 +1,10 @@
+package types
+
+// MsgWithdraw is the message to withdraw coins from the dex module account back to the user.
+type MsgWithdraw struct {
+	Creator string
+	Amount  string
+	Denom   string
+}
+
+type MsgWithdrawResponse struct{}

--- a/test/obs/test_withdraw.sh
+++ b/test/obs/test_withdraw.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# 1. Khai báo các biến cơ bản
+CHAIN_ID="ob"
+DENOM="ATOM"
+AMOUNT="1000$DENOM"
+USER_NAME="alice"
+
+echo -e "\033[0;34m[TEST] Bắt đầu quy trình kiểm tra Withdraw...\033[0m"
+
+# 2. Lấy địa chỉ ví của Alice từ bộ nhớ (keyring)
+ALICE_ADDR=$(obd keys show $USER_NAME -a --keyring-backend test)
+echo -e "Ví Alice: \033[0;32m$ALICE_ADDR\033[0m"
+
+# 3. Lấy địa chỉ ví của Module Account 'dex'
+MODULE_ADDR=$(obd q auth module-account dex --output json | python3 -c 'import sys,json; d=json.load(sys.stdin); v=d.get("account",{}).get("value",{}) or {}; addr=v.get("address") or ""; print(addr)')
+if [[ -z "$MODULE_ADDR" ]]; then
+  echo "Không lấy được địa chỉ module account 'dex'. Kiểm tra response query:" >&2
+  obd q auth module-account dex --output json >&2
+  exit 1
+fi
+echo -e "Ví Module DEX: \033[0;32m$MODULE_ADDR\033[0m"
+
+echo "---------------------------------------------------"
+echo "Số dư TRƯỚC khi Withdraw:"
+echo -e "\033[0;36mVí Alice:\033[0m"
+obd q bank balances $ALICE_ADDR
+
+echo -e "\033[0;36mVí Module:\033[0m"
+obd q bank balances $MODULE_ADDR
+
+echo "---------------------------------------------------"
+echo -e "\033[1;33m[STEP] Thực hiện rút $AMOUNT từ Module về ví Alice...\033[1;33m"
+# Gửi giao dịch
+obd tx dex withdraw $AMOUNT --from $USER_NAME --chain-id $CHAIN_ID --keyring-backend test -y
+
+# Đợi 5 giây để block được confirm
+echo "Đang đợi xử lý block..."
+sleep 5
+
+echo -e "\033[0;37m---------------------------------------------------\033[0m"
+echo -e "\033[0;37mSố dư SAU khi Withdraw:\033[0m"
+echo -e "\033[0;36mVí Alice (Phải tăng $AMOUNT):\033[0m"
+obd q bank balances $ALICE_ADDR
+
+echo -e "\033[0;36mVí Module (Phải giảm $AMOUNT):\033[0m"
+obd q bank balances $MODULE_ADDR


### PR DESCRIPTION
# [dev-ttn] Implement MsgWithdraw + unit tests (mock)

## What this PR does

Implements `MsgWithdraw` — withdrawal flow that sends coins from the dex module account back to the user.

## New files

| File | Description |
|---|---|
| `x/dex/keeper/withdraw.go` | Core logic: validates address & amount, calls `bankKeeper.SendCoinsFromModuleToAccount` |
| `x/dex/keeper/msg_server_withdraw.go` | Thin message handler, delegates to `Keeper.Withdraw` |
| `x/dex/types/msg_withdraw.go` | `MsgWithdraw` / `MsgWithdrawResponse` structs (manual until proto regen) |
| `x/dex/keeper/msg_server_withdraw_test.go` | 7 unit tests with mock `BankKeeper` |
| `test/obs/test_withdraw.sh` | E2E shell test for when chain is live |

## Modified files

| File | Description |
|---|---|
| `x/dex/types/errors.go` | Added `ErrInvalidAddress`, `ErrInvalidAmount` |

## Test results

```
--- PASS: TestWithdraw/success_—_full_balance
--- PASS: TestWithdraw/success_—_partial_amount
--- PASS: TestWithdraw/invalid_creator_address
--- PASS: TestWithdraw/invalid_amount_—_zero
--- PASS: TestWithdraw/invalid_amount_—_negative_string
--- PASS: TestWithdraw/invalid_amount_—_non-numeric
--- PASS: TestWithdraw/insufficient_module_funds
PASS  0.033s
```

## Notes for teammates

| Dependency | Status |
|---|---|
| MsgDeposit | Independent — withdraw doesn't touch deposit logic |
| Emit Event | `withdraw` event emitted in `Keeper.Withdraw` — align pattern after that branch merges |
| Proto regen | `MsgWithdraw` defined manually in `types/msg_withdraw.go` — replace with generated output after proto update |
| Backend module | Logic in `x/dex` for now — easy to relocate to `x/backend` if needed |

## How to test

```bash
# Unit tests (no chain needed)
cd sw/ob && go test ./x/dex/keeper/... -run TestWithdraw -v

# E2E (chain required)
ganc chain                     # terminal 1
ganc test -obs test_withdraw   # terminal 2