### PR TITLE
Appreciate 03-06

### DIFF
--- a/sw/ob/proto/ob/backend/v1/tx.proto
+++ b/sw/ob/proto/ob/backend/v1/tx.proto
@@ -21,6 +21,9 @@ service Msg {
 
   // Deposit defines the Deposit RPC.
   rpc Deposit(MsgDeposit) returns (MsgDepositResponse);
+
+  // Withdraw defines the Withdraw RPC.
+  rpc Withdraw(MsgWithdraw) returns (MsgWithdrawResponse);
 }
 
 // MsgUpdateParams is the Msg/UpdateParams request type.
@@ -53,3 +56,13 @@ message MsgDeposit {
 
 // MsgDepositResponse defines the MsgDepositResponse message.
 message MsgDepositResponse {}
+
+// MsgWithdraw defines the MsgWithdraw message.
+message MsgWithdraw {
+  option (cosmos.msg.v1.signer) = "creator";
+  string creator = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  cosmos.base.v1beta1.Coin amount = 2 [(gogoproto.nullable) = false];
+}
+
+// MsgWithdrawResponse defines the MsgWithdrawResponse message.
+message MsgWithdrawResponse {}

--- a/sw/ob/x/backend/keeper/msg_server_withdraw.go
+++ b/sw/ob/x/backend/keeper/msg_server_withdraw.go
@@ -1,0 +1,55 @@
+package keeper
+
+import (
+	"context"
+	"errors"
+
+	errorsmod "cosmossdk.io/errors"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"ob/x/backend/types"
+)
+
+func (k msgServer) Withdraw(goCtx context.Context, msg *types.MsgWithdraw) (*types.MsgWithdrawResponse, error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	if msg == nil {
+		return nil, errorsmod.Wrap(errors.New("nil withdraw message"), "invalid withdraw")
+	}
+	if msg.Creator == "" {
+		return nil, errorsmod.Wrap(errors.New("creator is required"), "invalid withdraw")
+	}
+	if err := msg.Amount.Validate(); err != nil {
+		return nil, errorsmod.Wrap(err, "invalid withdraw amount")
+	}
+	if msg.Amount.IsZero() {
+		return nil, errorsmod.Wrap(errors.New("withdraw amount must be > 0"), "invalid withdraw")
+	}
+
+	// Convert the address string to sdk.AccAddress.
+	recipient, err := sdk.AccAddressFromBech32(msg.Creator)
+	if err != nil {
+		return nil, errorsmod.Wrap(err, "invalid creator address")
+	}
+
+	// Transfer tokens from the backend module account back to the user.
+	err = k.bankKeeper.SendCoinsFromModuleToAccount(
+		ctx,
+		types.ModuleName,
+		recipient,
+		sdk.NewCoins(msg.Amount),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Emit events so that off-chain indexing can track withdrawals.
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			"backend_withdraw",
+			sdk.NewAttribute("recipient", recipient.String()),
+			sdk.NewAttribute("amount", msg.Amount.String()),
+		),
+	)
+
+	return &types.MsgWithdrawResponse{}, nil
+}

--- a/sw/ob/x/backend/keeper/msg_server_withdraw_test.go
+++ b/sw/ob/x/backend/keeper/msg_server_withdraw_test.go
@@ -1,0 +1,158 @@
+package keeper_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"cosmossdk.io/math"
+	storetypes "cosmossdk.io/store/types"
+	addresscodec "github.com/cosmos/cosmos-sdk/codec/address"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	"github.com/cosmos/cosmos-sdk/testutil"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/stretchr/testify/require"
+
+	"ob/x/backend/keeper"
+	module "ob/x/backend/module"
+	"ob/x/backend/types"
+)
+
+// mockBankKeeper is a controllable mock for types.BankKeeper.
+type mockBankKeeper struct {
+	moduleCoins sdk.Coins
+	sendErr     error
+}
+
+func newMockBankKeeper(moduleCoins sdk.Coins) *mockBankKeeper {
+	return &mockBankKeeper{moduleCoins: moduleCoins}
+}
+
+func (m *mockBankKeeper) SpendableCoins(_ context.Context, _ sdk.AccAddress) sdk.Coins {
+	return nil
+}
+
+func (m *mockBankKeeper) SendCoinsFromAccountToModule(_ context.Context, _ sdk.AccAddress, _ string, _ sdk.Coins) error {
+	return nil
+}
+
+func (m *mockBankKeeper) SendCoinsFromModuleToAccount(_ context.Context, _ string, _ sdk.AccAddress, amt sdk.Coins) error {
+	if m.sendErr != nil {
+		return m.sendErr
+	}
+	if !m.moduleCoins.IsAllGTE(amt) {
+		return errors.New("insufficient funds in module")
+	}
+	m.moduleCoins = m.moduleCoins.Sub(amt...)
+	return nil
+}
+
+// initFixtureWithBank creates a fixture wired with the given bank keeper mock.
+func initFixtureWithBank(t *testing.T, bank types.BankKeeper) *fixture {
+	t.Helper()
+
+	encCfg := moduletestutil.MakeTestEncodingConfig(module.AppModule{})
+	addressCodec := addresscodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix())
+	storeKey := storetypes.NewKVStoreKey(types.StoreKey)
+
+	storeService := runtime.NewKVStoreService(storeKey)
+	ctx := testutil.DefaultContextWithDB(t, storeKey, storetypes.NewTransientStoreKey("transient_test_withdraw")).Ctx
+
+	authority := authtypes.NewModuleAddress(types.GovModuleName)
+
+	k := keeper.NewKeeper(
+		storeService,
+		encCfg.Codec,
+		addressCodec,
+		authority,
+		nil,
+		bank,
+	)
+
+	if err := k.Params.Set(ctx, types.DefaultParams()); err != nil {
+		t.Fatalf("failed to set params: %v", err)
+	}
+
+	return &fixture{ctx: ctx, keeper: k, addressCodec: addressCodec}
+}
+
+func TestWithdraw(t *testing.T) {
+	validAddr, _ := addresscodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix()).
+		BytesToString([]byte("signerAddr__________________"))
+
+	moduleBalance := sdk.NewCoins(sdk.NewCoin("ATOM", math.NewInt(5000)))
+
+	tests := []struct {
+		desc    string
+		msg     *types.MsgWithdraw
+		bankErr error
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			desc: "success — full balance",
+			msg:  &types.MsgWithdraw{Creator: validAddr, Amount: sdk.NewCoin("ATOM", math.NewInt(1000))},
+		},
+		{
+			desc: "success — partial amount",
+			msg:  &types.MsgWithdraw{Creator: validAddr, Amount: sdk.NewCoin("ATOM", math.NewInt(500))},
+		},
+		{
+			desc:    "nil message",
+			msg:     nil,
+			wantErr: true,
+			errMsg:  "invalid withdraw",
+		},
+		{
+			desc:    "empty creator",
+			msg:     &types.MsgWithdraw{Creator: "", Amount: sdk.NewCoin("ATOM", math.NewInt(100))},
+			wantErr: true,
+			errMsg:  "invalid withdraw",
+		},
+		{
+			desc:    "invalid creator address",
+			msg:     &types.MsgWithdraw{Creator: "not-a-valid-address", Amount: sdk.NewCoin("ATOM", math.NewInt(100))},
+			wantErr: true,
+			errMsg:  "invalid creator address",
+		},
+		{
+			desc:    "zero amount",
+			msg:     &types.MsgWithdraw{Creator: validAddr, Amount: sdk.NewCoin("ATOM", math.NewInt(0))},
+			wantErr: true,
+			errMsg:  "invalid withdraw",
+		},
+		{
+			desc:    "bank returns insufficient funds",
+			msg:     &types.MsgWithdraw{Creator: validAddr, Amount: sdk.NewCoin("ATOM", math.NewInt(9999))},
+			wantErr: true,
+			errMsg:  "insufficient funds",
+		},
+		{
+			desc:    "bank returns arbitrary error",
+			msg:     &types.MsgWithdraw{Creator: validAddr, Amount: sdk.NewCoin("ATOM", math.NewInt(100))},
+			bankErr: errors.New("bank exploded"),
+			wantErr: true,
+			errMsg:  "bank exploded",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			bank := newMockBankKeeper(moduleBalance)
+			bank.sendErr = tc.bankErr
+			f := initFixtureWithBank(t, bank)
+
+			msgServer := keeper.NewMsgServerImpl(f.keeper)
+			_, err := msgServer.Withdraw(f.ctx, tc.msg)
+
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/sw/ob/x/backend/module/autocli.go
+++ b/sw/ob/x/backend/module/autocli.go
@@ -34,6 +34,12 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Short:          "Send a deposit tx",
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "amount"}},
 				},
+				{
+					RpcMethod:      "Withdraw",
+					Use:            "withdraw [amount]",
+					Short:          "Send a withdraw tx",
+					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "amount"}},
+				},
 				// this line is used by ignite scaffolding # autocli/tx
 			},
 		},

--- a/sw/ob/x/backend/types/codec.go
+++ b/sw/ob/x/backend/types/codec.go
@@ -12,6 +12,10 @@ func RegisterInterfaces(registrar codectypes.InterfaceRegistry) {
 	)
 
 	registrar.RegisterImplementations((*sdk.Msg)(nil),
+		&MsgWithdraw{},
+	)
+
+	registrar.RegisterImplementations((*sdk.Msg)(nil),
 		&MsgUpdateParams{},
 	)
 	msgservice.RegisterMsgServiceDesc(registrar, &_Msg_serviceDesc)

--- a/sw/ob/x/backend/types/expected_keepers.go
+++ b/sw/ob/x/backend/types/expected_keepers.go
@@ -19,6 +19,7 @@ type BankKeeper interface {
 	SpendableCoins(context.Context, sdk.AccAddress) sdk.Coins
 	// Methods imported from bank should be defined here
 	SendCoinsFromAccountToModule(ctx context.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
+	SendCoinsFromModuleToAccount(ctx context.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
 }
 
 // ParamSubspace defines the expected Subspace interface for parameters.

--- a/sw/ob/x/backend/types/tx.pb.go
+++ b/sw/ob/x/backend/types/tx.pb.go
@@ -215,11 +215,103 @@ func (m *MsgDepositResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_MsgDepositResponse proto.InternalMessageInfo
 
+// MsgWithdraw defines the MsgWithdraw message.
+type MsgWithdraw struct {
+	Creator string     `protobuf:"bytes,1,opt,name=creator,proto3" json:"creator,omitempty"`
+	Amount  types.Coin `protobuf:"bytes,2,opt,name=amount,proto3" json:"amount"`
+}
+
+func (m *MsgWithdraw) Reset()         { *m = MsgWithdraw{} }
+func (m *MsgWithdraw) String() string { return proto.CompactTextString(m) }
+func (*MsgWithdraw) ProtoMessage()    {}
+func (*MsgWithdraw) Descriptor() ([]byte, []int) {
+	return fileDescriptor_0253fd325020381e, []int{4}
+}
+func (m *MsgWithdraw) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgWithdraw) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgWithdraw.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgWithdraw) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgWithdraw.Merge(m, src)
+}
+func (m *MsgWithdraw) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgWithdraw) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgWithdraw.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgWithdraw proto.InternalMessageInfo
+
+func (m *MsgWithdraw) GetCreator() string {
+	if m != nil {
+		return m.Creator
+	}
+	return ""
+}
+
+func (m *MsgWithdraw) GetAmount() types.Coin {
+	if m != nil {
+		return m.Amount
+	}
+	return types.Coin{}
+}
+
+// MsgWithdrawResponse defines the MsgWithdrawResponse message.
+type MsgWithdrawResponse struct {
+}
+
+func (m *MsgWithdrawResponse) Reset()         { *m = MsgWithdrawResponse{} }
+func (m *MsgWithdrawResponse) String() string { return proto.CompactTextString(m) }
+func (*MsgWithdrawResponse) ProtoMessage()    {}
+func (*MsgWithdrawResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_0253fd325020381e, []int{5}
+}
+func (m *MsgWithdrawResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *MsgWithdrawResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_MsgWithdrawResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *MsgWithdrawResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_MsgWithdrawResponse.Merge(m, src)
+}
+func (m *MsgWithdrawResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *MsgWithdrawResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_MsgWithdrawResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_MsgWithdrawResponse proto.InternalMessageInfo
+
 func init() {
 	proto.RegisterType((*MsgUpdateParams)(nil), "ob.backend.v1.MsgUpdateParams")
 	proto.RegisterType((*MsgUpdateParamsResponse)(nil), "ob.backend.v1.MsgUpdateParamsResponse")
 	proto.RegisterType((*MsgDeposit)(nil), "ob.backend.v1.MsgDeposit")
 	proto.RegisterType((*MsgDepositResponse)(nil), "ob.backend.v1.MsgDepositResponse")
+	proto.RegisterType((*MsgWithdraw)(nil), "ob.backend.v1.MsgWithdraw")
+	proto.RegisterType((*MsgWithdrawResponse)(nil), "ob.backend.v1.MsgWithdrawResponse")
 }
 
 func init() { proto.RegisterFile("ob/backend/v1/tx.proto", fileDescriptor_0253fd325020381e) }
@@ -273,6 +365,8 @@ type MsgClient interface {
 	UpdateParams(ctx context.Context, in *MsgUpdateParams, opts ...grpc.CallOption) (*MsgUpdateParamsResponse, error)
 	// Deposit defines the Deposit RPC.
 	Deposit(ctx context.Context, in *MsgDeposit, opts ...grpc.CallOption) (*MsgDepositResponse, error)
+	// Withdraw defines the Withdraw RPC.
+	Withdraw(ctx context.Context, in *MsgWithdraw, opts ...grpc.CallOption) (*MsgWithdrawResponse, error)
 }
 
 type msgClient struct {
@@ -301,6 +395,15 @@ func (c *msgClient) Deposit(ctx context.Context, in *MsgDeposit, opts ...grpc.Ca
 	return out, nil
 }
 
+func (c *msgClient) Withdraw(ctx context.Context, in *MsgWithdraw, opts ...grpc.CallOption) (*MsgWithdrawResponse, error) {
+	out := new(MsgWithdrawResponse)
+	err := c.cc.Invoke(ctx, "/ob.backend.v1.Msg/Withdraw", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // MsgServer is the server API for Msg service.
 type MsgServer interface {
 	// UpdateParams defines a (governance) operation for updating the module
@@ -308,6 +411,8 @@ type MsgServer interface {
 	UpdateParams(context.Context, *MsgUpdateParams) (*MsgUpdateParamsResponse, error)
 	// Deposit defines the Deposit RPC.
 	Deposit(context.Context, *MsgDeposit) (*MsgDepositResponse, error)
+	// Withdraw defines the Withdraw RPC.
+	Withdraw(context.Context, *MsgWithdraw) (*MsgWithdrawResponse, error)
 }
 
 // UnimplementedMsgServer can be embedded to have forward compatible implementations.
@@ -319,6 +424,9 @@ func (*UnimplementedMsgServer) UpdateParams(ctx context.Context, req *MsgUpdateP
 }
 func (*UnimplementedMsgServer) Deposit(ctx context.Context, req *MsgDeposit) (*MsgDepositResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Deposit not implemented")
+}
+func (*UnimplementedMsgServer) Withdraw(ctx context.Context, req *MsgWithdraw) (*MsgWithdrawResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Withdraw not implemented")
 }
 
 func RegisterMsgServer(s grpc1.Server, srv MsgServer) {
@@ -361,6 +469,24 @@ func _Msg_Deposit_Handler(srv interface{}, ctx context.Context, dec func(interfa
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Msg_Withdraw_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MsgWithdraw)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MsgServer).Withdraw(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/ob.backend.v1.Msg/Withdraw",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MsgServer).Withdraw(ctx, req.(*MsgWithdraw))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var Msg_serviceDesc = _Msg_serviceDesc
 var _Msg_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "ob.backend.v1.Msg",
@@ -373,6 +499,10 @@ var _Msg_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Deposit",
 			Handler:    _Msg_Deposit_Handler,
+		},
+		{
+			MethodName: "Withdraw",
+			Handler:    _Msg_Withdraw_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -505,6 +635,69 @@ func (m *MsgDepositResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *MsgWithdraw) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgWithdraw) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgWithdraw) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	{
+		size, err := m.Amount.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintTx(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0x12
+	if len(m.Creator) > 0 {
+		i -= len(m.Creator)
+		copy(dAtA[i:], m.Creator)
+		i = encodeVarintTx(dAtA, i, uint64(len(m.Creator)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *MsgWithdrawResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *MsgWithdrawResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *MsgWithdrawResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintTx(dAtA []byte, offset int, v uint64) int {
 	offset -= sovTx(v)
 	base := offset
@@ -556,6 +749,30 @@ func (m *MsgDeposit) Size() (n int) {
 }
 
 func (m *MsgDepositResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *MsgWithdraw) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Creator)
+	if l > 0 {
+		n += 1 + l + sovTx(uint64(l))
+	}
+	l = m.Amount.Size()
+	n += 1 + l + sovTx(uint64(l))
+	return n
+}
+
+func (m *MsgWithdrawResponse) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -877,6 +1094,171 @@ func (m *MsgDepositResponse) Unmarshal(dAtA []byte) error {
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: MsgDepositResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgWithdraw) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgWithdraw: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgWithdraw: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Creator", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Creator = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Amount", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTx
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthTx
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthTx
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.Amount.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipTx(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthTx
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *MsgWithdrawResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowTx
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: MsgWithdrawResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: MsgWithdrawResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		default:

--- a/test/obs/smartc@withdraw.sh
+++ b/test/obs/smartc@withdraw.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Declare basic variables
+CHAIN_ID="ob"
+DENOM="ATOM"
+AMOUNT="1000$DENOM"
+USER_NAME="alice"
+
+B='\033[0;34m'
+G='\033[0;32m'
+R='\033[0;31m'
+Y='\033[1;33m'
+NC='\033[0m'
+
+echo -e "${Y}[TEST]         Withdraw token from smart contract...${NC}"
+
+# Retrieve Alice's wallet address from memory (keyring).
+echo -e "${G}[SYS]          Call 'obd keys show .. -a --keyring-backend test${NC}'"
+ALICE_ADDR=$(obd keys show $USER_NAME -a --keyring-backend test)
+echo -e "${B}[FIN]          Alice Wallet: ${Y}$ALICE_ADDR${NC}"
+
+# Get the wallet address of the 'backend' Account Module.
+echo -e "${G}[SYS]          Call 'obd q auth module-account backend --output json ...${NC}"
+MODULE_ADDR=$(obd q auth module-account backend --output json | python3 -c 'import sys,json; d=json.load(sys.stdin); v=d.get("account",{}).get("value",{}) or {}; addr=v.get("address") or ""; print(addr)')
+if [[ -z "$MODULE_ADDR" ]]; then
+  echo "${R}[SYS]          Unable to retrieve the address of the 'backend' account module. Check the query and response query:" >&2
+  obd q auth module-account backend --output json >&2
+  exit 1
+fi
+echo -e "${B}[FIN]          SmartC Wallet: ${Y}$MODULE_ADDR${NC}"
+
+
+# Balance
+echo -e "${G}[SYS]          Call 'obd q bank balances .. -o json ...'${NC}"
+BALANCE_ALICE=$(obd q bank balances $ALICE_ADDR -o json | jq -r '[.balances[] | .amount + .denom] | join(", ")')
+echo -e "${B}[BALANCE]      Alice Wallet: $BALANCE_ALICE${NC}"
+echo -e "${G}[SYS]          Call 'obd q bank balances .. -o json ...'${NC}"
+BALANCE_SC=$(obd q bank balances $MODULE_ADDR -o json | jq -r '[.balances[] | .amount + .denom] | join(", ")')
+echo -e "${B}[BALANCE]      SmartC Wallet: $BALANCE_SC${NC}"
+
+
+# Transaction
+echo -e "${Y}[SYS]          Send $AMOUNT from the Module back to Alice....${NC}}"
+echo -e "${G}[SYS]          Call 'obd tx backend withdraw .. --from .. --chain-id .. --keyring-backend test -y'${NC}"
+HANDLE_TRANSACTION=$(obd tx backend withdraw $AMOUNT --from $USER_NAME --chain-id $CHAIN_ID --keyring-backend test -y | awk '/txhash:/ {print $2}')
+echo -e "${B}[FIN]          Withdraw Tx: ${Y}$HANDLE_TRANSACTION${NC}"
+echo -e "${G}[SYS]          In progress ...${NC}"
+echo -e "${B}[TRANS]        Waiting  ...${NC}"
+sleep 5
+
+
+# Balance
+echo -e "${G}[SYS]          Call 'obd q bank balances .. -o json ...'${NC}"
+BALANCE_ALICE=$(obd q bank balances $ALICE_ADDR -o json | jq -r '[.balances[] | .amount + .denom] | join(", ")')
+echo -e "${B}[BALANCE]      Alice Wallet: $BALANCE_ALICE${NC}"
+echo -e "${G}[SYS]          Call 'obd q bank balances .. -o json ...'${NC}"
+BALANCE_SC=$(obd q bank balances $MODULE_ADDR -o json | jq -r '[.balances[] | .amount + .denom] | join(", ")')
+echo -e "${B}[BALANCE]      SmartC Wallet: $BALANCE_SC${NC}"


### PR DESCRIPTION
- Add Withdraw RPC to proto and tx.pb.go (mirrors MsgDeposit pattern)
- Add SendCoinsFromModuleToAccount to BankKeeper interface
- Add msg_server_withdraw.go: validates input, sends coins from backend module to user, emits backend_withdraw event
- Register MsgWithdraw in codec and autocli
- Add 8 unit tests with mock BankKeeper (no chain required)
- Add test/obs/smartc@withdraw.sh: e2e shell test for live chain